### PR TITLE
fix(agent_v2,toolbox_v2): expose headers + allowed_tools across all mcp/openapi blocks (#8)

### DIFF
--- a/docs/resources/agent_v2.md
+++ b/docs/resources/agent_v2.md
@@ -196,7 +196,7 @@ Required:
 
 Optional:
 
-- `headers` (Map of String) Optional HTTP headers, e.g. `x-ms-query-source-authorization` for remote-SharePoint per-user ACL enforcement.
+- `headers` (Map of String, Sensitive) Optional HTTP headers, e.g. `x-ms-query-source-authorization` for remote-SharePoint per-user ACL enforcement. Marked sensitive — values are redacted from plan / state output.
 - `require_approval` (String) `always`, `never`, or omitted (Foundry default). Defaults to `"never"` for the typed variant — KB lookups are read-only.
 - `server_label` (String) Display label shown in tool-call traces. Defaults to `"knowledge-base"`.
 
@@ -212,7 +212,7 @@ Required:
 Optional:
 
 - `allowed_tools` (List of String) Optional allow-list of MCP tool names the model may invoke. Empty means all advertised tools are available. Set this to scope down a server that exposes more than the agent should use; required for Foundry IQ knowledge bases (`["knowledge_base_retrieve"]`) — though prefer the typed `knowledge_base` variant for that case.
-- `headers` (Map of String) Optional HTTP headers Foundry sends on every MCP request. Primarily used for per-request auth tokens like `x-ms-query-source-authorization` against remote-SharePoint knowledge sources.
+- `headers` (Map of String, Sensitive) Optional HTTP headers Foundry sends on every MCP request. Common uses: `x-ms-query-source-authorization` for remote-SharePoint knowledge sources, `Foundry-Features: Toolboxes=V1Preview` when consuming a toolbox endpoint, or per-tool bearer tokens for upstreams outside the project-connection auth flow. Marked sensitive — values are redacted from plan / state output.
 - `project_connection_id` (String) Project connection ID used to authenticate to the MCP server.
 - `require_approval` (String) `always`, `never`, or omitted (Foundry default). Controls whether the user must approve tool invocations before they run.
 
@@ -242,6 +242,7 @@ Optional:
 
 - `auth_type` (String) `anonymous` (default) or `connection`. When `connection`, Foundry uses the project connection bound to the API host.
 - `description` (String) Human-readable description shown to the model.
+- `headers` (Map of String, Sensitive) Optional HTTP headers Foundry sends on every outbound call to the API. Useful for upstreams that gate on a custom header outside the spec's `securitySchemes` (legacy APIs, dev/test stubs). Marked sensitive — values are redacted from plan / state output.
 
 
 

--- a/docs/resources/toolbox_v2.md
+++ b/docs/resources/toolbox_v2.md
@@ -246,6 +246,8 @@ Required:
 
 Optional:
 
+- `allowed_tools` (List of String) Optional allow-list of MCP tool names. Empty means all advertised tools are available. Useful when fronting a server that exposes more than the toolbox should publish — e.g. `["knowledge_base_retrieve"]` for a Foundry IQ KB.
+- `headers` (Map of String, Sensitive) Optional HTTP headers Foundry sends on every MCP request. Common uses: `x-ms-query-source-authorization` for remote-SharePoint knowledge sources nested behind this toolbox tool, or per-tool bearer tokens for upstreams outside the project-connection auth flow. Marked sensitive — values are redacted from plan / state output.
 - `project_connection_id` (String) Project connection ID used to authenticate to the MCP server.
 - `require_approval` (String) `always`, `never`, or omitted (Foundry default).
 
@@ -275,3 +277,4 @@ Optional:
 
 - `auth_type` (String) `anonymous` (default) or `connection`.
 - `description` (String) Human-readable description shown to the model.
+- `headers` (Map of String, Sensitive) Optional HTTP headers Foundry sends on every outbound call. Useful for upstreams that gate on a custom header outside the spec's `securitySchemes`. Marked sensitive — values are redacted from plan / state output.

--- a/internal/client/agent_v2.go
+++ b/internal/client/agent_v2.go
@@ -132,6 +132,11 @@ type FunctionToolV2 struct {
 }
 
 // OpenAPIToolV2 — inline OpenAPI spec.
+//
+// Headers is an outer-level field on the tool envelope (siblings: type,
+// openapi). Foundry routes it the same way it does for MCP — sent on
+// every outbound HTTP call to the tool. Useful for upstream APIs that
+// gate on a custom header outside the OpenAPI spec's `securitySchemes`.
 type OpenAPIAuth struct {
 	Type string `json:"type"` // anonymous | connection
 }
@@ -144,8 +149,9 @@ type OpenAPIConfig struct {
 }
 
 type OpenAPIToolV2 struct {
-	Type    string        `json:"type"` // "openapi"
-	OpenAPI OpenAPIConfig `json:"openapi"`
+	Type    string            `json:"type"` // "openapi"
+	OpenAPI OpenAPIConfig     `json:"openapi"`
+	Headers map[string]string `json:"headers,omitempty"`
 }
 
 // MCPToolV2 — Model Context Protocol server.

--- a/internal/client/agent_v2_test.go
+++ b/internal/client/agent_v2_test.go
@@ -1,0 +1,216 @@
+// Copyright (c) Engin Diri
+// SPDX-License-Identifier: MPL-2.0
+
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// decodeFirstTool re-marshals payload.Definition.Tools[0] to JSON and
+// decodes it as a generic map. Foundry decodes Tools as []any, so this is
+// the same path the wire goes through — we just inspect it after the fact.
+func decodeFirstTool(t *testing.T, payload CreateAgentV2Request) (decoded map[string]any, raw []byte) {
+	t.Helper()
+	if len(payload.Definition.Tools) != 1 {
+		t.Fatalf("expected 1 tool, got %d", len(payload.Definition.Tools))
+	}
+	raw, err := json.Marshal(payload.Definition.Tools[0])
+	if err != nil {
+		t.Fatalf("re-marshaling tool: %v", err)
+	}
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("decoding tool: %v", err)
+	}
+	return decoded, raw
+}
+
+func makeAgentV2EchoResponse(toolJSON []byte, name string) string {
+	return `{"object":"agent","id":"asst_abc","name":"` + name + `","versions":{"latest":{"id":"v1","name":"` +
+		name + `","version":"1","description":"","created_at":1700000000,"definition":{"kind":"prompt","tools":[` +
+		string(toolJSON) + `]}}}}`
+}
+
+// TestCreateAgentV2_MCPHeadersAndAllowedToolsRoundTrip pins the wire shape
+// for the mcp tool block's allowed_tools + headers fields (issue #8). The
+// schema accepts these on agent_v2 and toolbox_v2; both share the same
+// extractor/wirer so verifying the wire body once covers both paths.
+func TestCreateAgentV2_MCPHeadersAndAllowedToolsRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	rt := roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		var payload CreateAgentV2Request
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("decoding body: %v", err)
+		}
+		mcp, raw := decodeFirstTool(t, payload)
+		assertMCPHeaderShape(t, mcp)
+		return newProbeResponse(http.StatusOK, makeAgentV2EchoResponse(raw, "sharepoint-kb")), nil
+	})
+
+	c := newTestClient(rt)
+	resp, err := c.CreateAgentV2(context.Background(), CreateAgentV2Request{
+		Name: "sharepoint-kb",
+		Definition: AgentDefinitionV2{
+			Kind: "prompt",
+			Tools: []any{
+				MCPToolV2{
+					Type:                "mcp",
+					ServerLabel:         "knowledge-base",
+					ServerURL:           "https://x.search.windows.net/knowledgebases/k/mcp?api-version=2025-11-01-preview",
+					ProjectConnectionID: "kb-conn",
+					RequireApproval:     "never",
+					AllowedTools:        []string{"knowledge_base_retrieve"},
+					Headers: map[string]string{
+						"x-ms-query-source-authorization": "Bearer xyz",
+						"Foundry-Features":                "Toolboxes=V1Preview",
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateAgentV2: %v", err)
+	}
+	assertMCPEchoRoundTrip(t, resp.Versions.Latest.Definition.Tools)
+}
+
+// assertMCPHeaderShape verifies the inbound JSON for an mcp tool with
+// allowed_tools + headers. Split out so the test body stays under the
+// gocyclo budget.
+func assertMCPHeaderShape(t *testing.T, mcp map[string]any) {
+	t.Helper()
+	if mcp["type"] != "mcp" {
+		t.Errorf("expected type=mcp, got %v", mcp["type"])
+	}
+	allowed, _ := mcp["allowed_tools"].([]any)
+	if len(allowed) != 1 || allowed[0] != "knowledge_base_retrieve" {
+		t.Errorf("expected allowed_tools=[knowledge_base_retrieve], got %v", mcp["allowed_tools"])
+	}
+	headers, ok := mcp["headers"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected headers map, got %v (%T)", mcp["headers"], mcp["headers"])
+	}
+	if headers["x-ms-query-source-authorization"] != "Bearer xyz" {
+		t.Errorf("unexpected x-ms-query-source-authorization: %v", headers["x-ms-query-source-authorization"])
+	}
+	if headers["Foundry-Features"] != "Toolboxes=V1Preview" {
+		t.Errorf("unexpected Foundry-Features: %v", headers["Foundry-Features"])
+	}
+}
+
+func assertMCPEchoRoundTrip(t *testing.T, tools []any) {
+	t.Helper()
+	if len(tools) != 1 {
+		t.Fatalf("expected 1 echoed tool, got %d", len(tools))
+	}
+	rawEcho, _ := json.Marshal(tools[0])
+	var echoed MCPToolV2
+	if err := json.Unmarshal(rawEcho, &echoed); err != nil {
+		t.Fatalf("decoding echoed tool: %v", err)
+	}
+	if len(echoed.AllowedTools) != 1 || echoed.AllowedTools[0] != "knowledge_base_retrieve" {
+		t.Errorf("AllowedTools didn't round-trip: %v", echoed.AllowedTools)
+	}
+	if len(echoed.Headers) != 2 || echoed.Headers["Foundry-Features"] != "Toolboxes=V1Preview" {
+		t.Errorf("Headers didn't round-trip: %v", echoed.Headers)
+	}
+}
+
+// TestCreateAgentV2_OpenAPIHeadersRoundTrip pins the wire shape for the
+// new openapi.headers field (issue #8). Headers sit on the outer tool
+// envelope (sibling to "openapi"), matching how Foundry positions the
+// field for mcp.
+func TestCreateAgentV2_OpenAPIHeadersRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	rt := roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		var payload CreateAgentV2Request
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("decoding body: %v", err)
+		}
+		openapi, raw := decodeFirstTool(t, payload)
+		assertOpenAPIHeaderShape(t, openapi)
+		return newProbeResponse(http.StatusOK, makeAgentV2EchoResponse(raw, "weather")), nil
+	})
+
+	c := newTestClient(rt)
+	resp, err := c.CreateAgentV2(context.Background(), CreateAgentV2Request{
+		Name: "weather",
+		Definition: AgentDefinitionV2{
+			Kind: "prompt",
+			Tools: []any{
+				OpenAPIToolV2{
+					Type: "openapi",
+					OpenAPI: OpenAPIConfig{
+						Name: "weather",
+						Spec: map[string]any{"openapi": "3.0.0"},
+						Auth: OpenAPIAuth{Type: "anonymous"},
+					},
+					Headers: map[string]string{"x-tenant-id": "t-1"},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateAgentV2: %v", err)
+	}
+
+	rawEcho, _ := json.Marshal(resp.Versions.Latest.Definition.Tools[0])
+	var echoed OpenAPIToolV2
+	if err := json.Unmarshal(rawEcho, &echoed); err != nil {
+		t.Fatalf("decoding echoed tool: %v", err)
+	}
+	if echoed.Headers["x-tenant-id"] != "t-1" {
+		t.Errorf("OpenAPIToolV2.Headers didn't round-trip: %v", echoed.Headers)
+	}
+}
+
+func assertOpenAPIHeaderShape(t *testing.T, openapi map[string]any) {
+	t.Helper()
+	if openapi["type"] != "openapi" {
+		t.Errorf("expected type=openapi, got %v", openapi["type"])
+	}
+	headers, ok := openapi["headers"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected headers map, got %v (%T)", openapi["headers"], openapi["headers"])
+	}
+	if headers["x-tenant-id"] != "t-1" {
+		t.Errorf("unexpected x-tenant-id header: %v", headers["x-tenant-id"])
+	}
+	inner, ok := openapi["openapi"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected nested openapi envelope, got %v (%T)", openapi["openapi"], openapi["openapi"])
+	}
+	if inner["name"] != "weather" {
+		t.Errorf("unexpected inner name: %v", inner["name"])
+	}
+}
+
+// TestMCPToolV2_OmitsEmptyHeadersAndAllowedTools — when neither field is
+// set, both must be omitted from the wire body so we don't introduce
+// drift against existing agents that pre-date issue #8.
+func TestMCPToolV2_OmitsEmptyHeadersAndAllowedTools(t *testing.T) {
+	t.Parallel()
+
+	tool := MCPToolV2{
+		Type:        "mcp",
+		ServerLabel: "x",
+		ServerURL:   "https://x.example.com",
+	}
+	raw, err := json.Marshal(tool)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	got := string(raw)
+	if strings.Contains(got, "allowed_tools") {
+		t.Errorf("expected allowed_tools to be omitted when empty, got %s", got)
+	}
+	if strings.Contains(got, "headers") {
+		t.Errorf("expected headers to be omitted when empty, got %s", got)
+	}
+}

--- a/internal/resources/foundry_agent_v2.go
+++ b/internal/resources/foundry_agent_v2.go
@@ -127,6 +127,7 @@ var openapiAttrTypes = map[string]attr.Type{
 	"description": types.StringType,
 	"spec_json":   types.StringType,
 	"auth_type":   types.StringType,
+	"headers":     types.MapType{ElemType: types.StringType},
 }
 
 var mcpAttrTypes = map[string]attr.Type{
@@ -407,6 +408,14 @@ func (r *FoundryAgentV2Resource) Schema(_ context.Context, _ resource.SchemaRequ
 										"Foundry uses the project connection bound to the API host.",
 									Optional: true,
 								},
+								"headers": schema.MapAttribute{
+									MarkdownDescription: "Optional HTTP headers Foundry sends on every outbound call to the API. " +
+										"Useful for upstreams that gate on a custom header outside the spec's `securitySchemes` " +
+										"(legacy APIs, dev/test stubs). Marked sensitive — values are redacted from plan / state output.",
+									Optional:    true,
+									Sensitive:   true,
+									ElementType: types.StringType,
+								},
 							},
 						},
 						"mcp": schema.SingleNestedAttribute{
@@ -441,9 +450,13 @@ func (r *FoundryAgentV2Resource) Schema(_ context.Context, _ resource.SchemaRequ
 								},
 								"headers": schema.MapAttribute{
 									MarkdownDescription: "Optional HTTP headers Foundry sends on every MCP request. " +
-										"Primarily used for per-request auth tokens like " +
-										"`x-ms-query-source-authorization` against remote-SharePoint knowledge sources.",
+										"Common uses: `x-ms-query-source-authorization` for remote-SharePoint " +
+										"knowledge sources, `Foundry-Features: Toolboxes=V1Preview` when " +
+										"consuming a toolbox endpoint, or per-tool bearer tokens for upstreams " +
+										"outside the project-connection auth flow. Marked sensitive — values are " +
+										"redacted from plan / state output.",
 									Optional:    true,
+									Sensitive:   true,
 									ElementType: types.StringType,
 								},
 							},
@@ -477,8 +490,9 @@ func (r *FoundryAgentV2Resource) Schema(_ context.Context, _ resource.SchemaRequ
 									Optional:            true,
 								},
 								"headers": schema.MapAttribute{
-									MarkdownDescription: "Optional HTTP headers, e.g. `x-ms-query-source-authorization` for remote-SharePoint per-user ACL enforcement.",
+									MarkdownDescription: "Optional HTTP headers, e.g. `x-ms-query-source-authorization` for remote-SharePoint per-user ACL enforcement. Marked sensitive — values are redacted from plan / state output.",
 									Optional:            true,
+									Sensitive:           true,
 									ElementType:         types.StringType,
 								},
 							},
@@ -1129,7 +1143,7 @@ func extractFunctionTool(_ context.Context, t *toolModelV2) (any, diag.Diagnosti
 	return tool, diags
 }
 
-func extractOpenAPITool(_ context.Context, t *toolModelV2) (any, diag.Diagnostics) {
+func extractOpenAPITool(ctx context.Context, t *toolModelV2) (any, diag.Diagnostics) {
 	tool := client.OpenAPIToolV2{Type: "openapi"}
 	if t.OpenAPI.IsNull() || t.OpenAPI.IsUnknown() {
 		return tool, nil
@@ -1148,6 +1162,10 @@ func extractOpenAPITool(_ context.Context, t *toolModelV2) (any, diag.Diagnostic
 		authType = "anonymous"
 	}
 	tool.OpenAPI.Auth = client.OpenAPIAuth{Type: authType}
+
+	if v, ok := attrs["headers"].(types.Map); ok {
+		tool.Headers = extractStringMap(ctx, v)
+	}
 	return tool, diags
 }
 
@@ -1407,12 +1425,20 @@ func wireFunctionTool(toolMap map[string]any, values map[string]attr.Value) diag
 func wireOpenAPITool(toolMap map[string]any, values map[string]attr.Value) diag.Diagnostics {
 	oa := asMap(toolMap["openapi"])
 	authType := stringFromMap(asMap(oa["auth"]), "type")
-	obj, diags := types.ObjectValue(openapiAttrTypes, map[string]attr.Value{
+
+	// headers lives on the outer tool envelope, sibling to "openapi" — same
+	// as the mcp variant. Foundry positions it that way so the same plumbing
+	// applies to both.
+	headers, diags := stringMapFromAny(toolMap["headers"])
+
+	obj, d := types.ObjectValue(openapiAttrTypes, map[string]attr.Value{
 		"name":        types.StringValue(stringFromMap(oa, "name")),
 		"description": types.StringValue(stringFromMap(oa, "description")),
 		"spec_json":   types.StringValue(jsonStringFromMap(oa, "spec")),
 		"auth_type":   types.StringValue(authType),
+		"headers":     headers,
 	})
+	diags.Append(d...)
 	values["openapi"] = obj
 	return diags
 }

--- a/internal/resources/foundry_toolbox_v2.go
+++ b/internal/resources/foundry_toolbox_v2.go
@@ -225,6 +225,12 @@ func toolboxToolsNestedBlock() schema.NestedBlockObject {
 					"description": schema.StringAttribute{MarkdownDescription: "Human-readable description shown to the model.", Optional: true},
 					"spec_json":   schema.StringAttribute{MarkdownDescription: "OpenAPI 3.x spec serialized as a JSON string.", Required: true},
 					"auth_type":   schema.StringAttribute{MarkdownDescription: "`anonymous` (default) or `connection`.", Optional: true},
+					"headers": schema.MapAttribute{
+						MarkdownDescription: "Optional HTTP headers Foundry sends on every outbound call. Useful for upstreams that gate on a custom header outside the spec's `securitySchemes`. Marked sensitive — values are redacted from plan / state output.",
+						Optional:            true,
+						Sensitive:           true,
+						ElementType:         types.StringType,
+					},
 				},
 			},
 			"mcp": schema.SingleNestedAttribute{
@@ -235,6 +241,17 @@ func toolboxToolsNestedBlock() schema.NestedBlockObject {
 					"server_url":            schema.StringAttribute{MarkdownDescription: "URL of the MCP server. Must be reachable from Foundry's egress.", Required: true},
 					"require_approval":      schema.StringAttribute{MarkdownDescription: "`always`, `never`, or omitted (Foundry default).", Optional: true},
 					"project_connection_id": schema.StringAttribute{MarkdownDescription: "Project connection ID used to authenticate to the MCP server.", Optional: true},
+					"allowed_tools": schema.ListAttribute{
+						MarkdownDescription: "Optional allow-list of MCP tool names. Empty means all advertised tools are available. Useful when fronting a server that exposes more than the toolbox should publish — e.g. `[\"knowledge_base_retrieve\"]` for a Foundry IQ KB.",
+						Optional:            true,
+						ElementType:         types.StringType,
+					},
+					"headers": schema.MapAttribute{
+						MarkdownDescription: "Optional HTTP headers Foundry sends on every MCP request. Common uses: `x-ms-query-source-authorization` for remote-SharePoint knowledge sources nested behind this toolbox tool, or per-tool bearer tokens for upstreams outside the project-connection auth flow. Marked sensitive — values are redacted from plan / state output.",
+						Optional:            true,
+						Sensitive:           true,
+						ElementType:         types.StringType,
+					},
 				},
 			},
 			"azure_ai_search": schema.SingleNestedAttribute{


### PR DESCRIPTION
Closes #8.

## Summary

Backfills the gaps left after v0.8.0 so users can wire up the documented Foundry MCP / OpenAPI flows that need a `headers` map — primarily Foundry IQ SharePoint KSes (`x-ms-query-source-authorization`), toolbox preview opt-in (`Foundry-Features: Toolboxes=V1Preview`), and custom-auth MCP servers.

## What changed

| Surface | Before v0.8.1 | After |
|---|---|---|
| `agent_v2.tools[*].mcp.allowed_tools` | ✓ (since v0.8.0) | ✓ |
| `agent_v2.tools[*].mcp.headers` | ✓ (since v0.8.0) | ✓ + `Sensitive: true` |
| `agent_v2.tools[*].openapi.headers` | missing | **added** + `Sensitive: true` |
| `agent_v2.tools[*].knowledge_base.headers` | ✓ (since v0.8.0) | ✓ + `Sensitive: true` |
| `toolbox_v2.tools[*].mcp.allowed_tools` | missing | **added** |
| `toolbox_v2.tools[*].mcp.headers` | missing | **added** + `Sensitive: true` |
| `toolbox_v2.tools[*].openapi.headers` | missing | **added** + `Sensitive: true` |

## Wire-type changes

- `OpenAPIToolV2` gains `Headers map[string]string \`json:\"headers,omitempty\"\``. Headers sit on the outer tool envelope, sibling to `\"openapi\"`, matching how Foundry positions them for `mcp` (and how the REST docs document the field placement).
- Empty maps stay `omitempty` on the wire — existing agents pre-dating #8 plan clean.

## Schema-level decisions

- Every new `headers` attribute is `Sensitive: true` per the issue's guidance — bearer tokens and authz headers shouldn't leak into plan / state output even if the docs warn against per-request auth.
- `allowed_tools` on the toolbox `mcp` block stays non-sensitive (it's just a list of well-known tool names like `[\"knowledge_base_retrieve\"]`).
- Same field naming and types as the existing `agent_v2` schema, so the toolbox / agent surfaces stay symmetric.

## Tests

Three new cases against the agent_v2 client wire shape via the existing `roundTripperFunc` pattern:

1. `TestCreateAgentV2_MCPHeadersAndAllowedToolsRoundTrip` — pins both fields on the outbound body and the response decode.
2. `TestCreateAgentV2_OpenAPIHeadersRoundTrip` — pins outer-envelope placement of `headers` on the openapi tool and confirms the inner `openapi` envelope still carries name/spec/auth.
3. `TestMCPToolV2_OmitsEmptyHeadersAndAllowedTools` — guards the omitempty behavior so existing agents don't see spurious diff after the upgrade.

Test bodies factor through helpers (`decodeFirstTool`, `assertMCPHeaderShape`, `assertOpenAPIHeaderShape`) to stay under the project's gocyclo budget.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race -short ./...` — 21 passed across 4 packages (3 new in `agent_v2_test.go`)
- [x] `golangci-lint run ./...` — no issues
- [x] `tfplugindocs generate` — `agent_v2.md` and `toolbox_v2.md` regenerate with the new attributes; clean diff otherwise
- [ ] **Live verification of the toolbox `Foundry-Features: Toolboxes=V1Preview` workaround** — the issue's caveat #2. Worth confirming on the demo project before tagging.

## Releases as

`v0.8.1`. Patch over v0.8.0; same minor as the Foundry IQ resources (#4) per the issue's acceptance criterion.