### PR TITLE
fix(project-index): use PATCH not PUT for create_or_update (#12)

### DIFF
--- a/internal/client/project_index_v2.go
+++ b/internal/client/project_index_v2.go
@@ -83,25 +83,35 @@ func (c *FoundryClient) projectIndexURL(name, version string) string {
 		c.ProjectEndpoint, url.PathEscape(name), url.PathEscape(version), ProjectIndexAPIVersion)
 }
 
-// CreateOrUpdateProjectIndex upserts a single (name, version) pair. The
-// underlying HTTP method is PUT with content-type application/merge-patch+json
-// per the SDK contract — every call replaces the prior body wholesale,
-// matching how Terraform Update wants to think about it.
+// CreateOrUpdateProjectIndex upserts a single (name, version) pair.
+//
+// Wire shape: HTTP **PATCH** with Content-Type
+// `application/merge-patch+json` (RFC 7396). The Python SDK calls this
+// `create_or_update` which sounds like PUT semantics, but the underlying
+// transport is PATCH — verified against
+// `azure-sdk-for-python/.../operations/_operations.py:795`
+// (`build_indexes_create_or_update_request` → `HttpRequest(method="PATCH", …)`).
+// Every call replaces the prior body wholesale, matching how Terraform
+// Update wants to think about it.
+//
+// v0.8.2 issued PUT against the same URL and got HTTP 404 from the live
+// service in swedencentral — see issue #12. The fix is the verb, nothing
+// else: URL template, api-version, content-type were all already correct.
 func (c *FoundryClient) CreateOrUpdateProjectIndex(ctx context.Context, idx ProjectIndex) (*ProjectIndex, error) {
 	if idx.Version == "" {
 		idx.Version = ProjectIndexDefaultVersion
 	}
 	target := c.projectIndexURL(idx.Name, idx.Version)
-	httpReq, err := c.newRequest(ctx, http.MethodPut, target, idx)
+	httpReq, err := c.newRequest(ctx, http.MethodPatch, target, idx)
 	if err != nil {
 		return nil, err
 	}
-	// merge-patch+json signals a partial-update upsert — required by the
-	// service per the Python SDK's content-type default.
+	// merge-patch+json signals an RFC 7396 partial-update upsert —
+	// required by the service per the Python SDK's content-type default.
 	httpReq.Header.Set("Content-Type", "application/merge-patch+json")
 	resp, err := c.httpClient.Do(httpReq)
 	if err != nil {
-		return nil, fmt.Errorf("project index PUT HTTP error (%s): %w", target, err)
+		return nil, fmt.Errorf("project index PATCH HTTP error (%s): %w", target, err)
 	}
 	defer closeBody(resp)
 	if err := checkResponseError(resp); err != nil {

--- a/internal/client/project_index_v2_test.go
+++ b/internal/client/project_index_v2_test.go
@@ -16,8 +16,11 @@ func TestCreateOrUpdateProjectIndex_RoundTripsAzureSearchBody(t *testing.T) {
 	t.Parallel()
 
 	rt := roundTripperFunc(func(r *http.Request) (*http.Response, error) {
-		if r.Method != http.MethodPut {
-			t.Errorf("expected PUT, got %s", r.Method)
+		// PATCH, not PUT — `create_or_update` in the SDK is RFC 7396 merge-
+		// patch transport. v0.8.2 used PUT and got 404 from the live
+		// service (issue #12); the URL template stayed correct.
+		if r.Method != http.MethodPatch {
+			t.Errorf("expected PATCH, got %s", r.Method)
 		}
 		if !strings.HasSuffix(r.URL.Path, "/indexes/fraud-policies-index/versions/1") {
 			t.Errorf("unexpected path: %s", r.URL.Path)


### PR DESCRIPTION
Closes #12.

## Root cause

v0.8.2 issued HTTP `PUT` against `{project}/indexes/{name}/versions/{version}` and got 404 from live Foundry in `swedencentral`. URL template, api-version (`v1`), and content-type (`application/merge-patch+json`) were all correct in v0.8.2 — the bug was the verb.

The SDK calls this operation `create_or_update` which sounds like PUT-style upsert semantics, but the underlying transport is **PATCH** with a merge-patch body (RFC 7396). Verified against the canonical [azure-sdk-for-python source](https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/ai/azure-ai-projects/azure/ai/projects/operations/_operations.py):

```python
# sdk/ai/azure-ai-projects/.../operations/_operations.py:795
def build_indexes_create_or_update_request(name: str, version: str, **kwargs):
    ...
    _url = \"/indexes/{name}/versions/{version}\"
    ...
    return HttpRequest(method=\"PATCH\", url=_url, params=_params, headers=_headers, **kwargs)
```

The `application/merge-patch+json` content-type that v0.8.2 already set is the giveaway — RFC 7396 is PATCH-only by spec. The reporter's diagnostic table on #12 also exhausted PUT URL/api-version variants but never tried PATCH for the same naming-confusion reason.

## Fix

One-line client change: `http.MethodPut` → `http.MethodPatch` in `CreateOrUpdateProjectIndex`. Test asserts the new verb. Comment in the client explains why so the next reader doesn't repeat the mistake.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race -short ./...` — 26 passed across 4 packages
- [x] `golangci-lint run ./...` — no issues
- [ ] **Live verification by the reporter** — the actual bug repro lives on a real Foundry project. The unit test pins the new wire shape but doesn't catch a subsequent live regression. If the live PATCH still 404s, that means the URL template is also wrong (which would contradict the SDK source — surprising but worth tagging fast and re-cutting if needed).

## Releases as

`v0.8.3`. Patch bump.