### PR TITLE
fix(project-index): flat camelCase wire body for AzureSearch indexes (#14)

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -134,3 +134,11 @@ linters:
       - path: internal/client/(knowledge_source_v2|knowledge_base_v2)\.go
         linters:
           - tagliatelle
+      # Foundry project_indexes uses camelCase JSON keys (connectionName,
+      # indexName, fieldMapping, …) per the SDK's rest_field annotations
+      # in azure-ai-projects/.../models/_models.py. Different from the
+      # snake_case Foundry-agent convention — the Indexes API is shaped
+      # like the AzureML asset surface.
+      - path: internal/client/project_index_v2\.go
+        linters:
+          - tagliatelle

--- a/internal/client/project_index_v2.go
+++ b/internal/client/project_index_v2.go
@@ -46,9 +46,21 @@ const ProjectIndexDefaultVersion = "1"
 const ProjectIndexTypeAzureSearch = "AzureSearch"
 
 // ProjectIndex is the wire envelope. The variant-specific fields
-// (connection_name, index_name, field_mapping) live on the same object
-// as the discriminator — Foundry doesn't nest them under a per-type
-// sub-object the way the agent tools do.
+// (connectionName, indexName, fieldMapping) live FLAT on the same
+// object as the discriminator — Foundry doesn't nest them under a
+// per-type sub-object the way the agent tools do.
+//
+// Wire keys are camelCase per the Python SDK's rest_field annotations
+// in azure-ai-projects/.../models/_models.py:
+//
+//	connection_name: str = rest_field(name="connectionName", …)
+//	index_name:      str = rest_field(name="indexName", …)
+//	field_mapping:   ... = rest_field(name="fieldMapping", …)
+//
+// v0.8.2 / v0.8.3 used snake_case JSON tags here; Foundry validated the
+// flat envelope, didn't see connectionName / indexName, and returned 400
+// "ConnectionName field is required". Issue #14 captured the verbatim
+// 200-response shape — this struct now matches.
 type ProjectIndex struct {
 	Name           string            `json:"name"`
 	Version        string            `json:"version"`
@@ -56,22 +68,23 @@ type ProjectIndex struct {
 	ID             string            `json:"id,omitempty"`
 	Description    string            `json:"description,omitempty"`
 	Tags           map[string]string `json:"tags,omitempty"`
-	ConnectionName string            `json:"connection_name,omitempty"`
-	IndexName      string            `json:"index_name,omitempty"`
-	FieldMapping   *FieldMapping     `json:"field_mapping,omitempty"`
+	ConnectionName string            `json:"connectionName,omitempty"`
+	IndexName      string            `json:"indexName,omitempty"`
+	FieldMapping   *FieldMapping     `json:"fieldMapping,omitempty"`
 }
 
 // FieldMapping is the optional column-rename envelope on AzureAISearchIndex.
 // Empty pointer means "use the index's default schema". Specific fields
 // stay strings even when they're nullable on the wire — the resource
-// layer translates "" → null to keep the round-trip clean.
+// layer translates "" → null to keep the round-trip clean. JSON keys are
+// camelCase per the SDK's rest_field annotations.
 type FieldMapping struct {
-	ContentFields  []string `json:"content_fields,omitempty"`
-	FilepathField  string   `json:"filepath_field,omitempty"`
-	TitleField     string   `json:"title_field,omitempty"`
-	URLField       string   `json:"url_field,omitempty"`
-	VectorFields   []string `json:"vector_fields,omitempty"`
-	MetadataFields []string `json:"metadata_fields,omitempty"`
+	ContentFields  []string `json:"contentFields,omitempty"`
+	FilepathField  string   `json:"filepathField,omitempty"`
+	TitleField     string   `json:"titleField,omitempty"`
+	URLField       string   `json:"urlField,omitempty"`
+	VectorFields   []string `json:"vectorFields,omitempty"`
+	MetadataFields []string `json:"metadataFields,omitempty"`
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/internal/client/project_index_v2_test.go
+++ b/internal/client/project_index_v2_test.go
@@ -49,7 +49,7 @@ func TestCreateOrUpdateProjectIndex_RoundTripsAzureSearchBody(t *testing.T) {
 			t.Errorf("expected version=1, got %q", payload.Version)
 		}
 
-		body := `{"name":"fraud-policies-index","version":"1","type":"AzureSearch","id":"idx_abc","connection_name":"search-conn","index_name":"fraud-policies-ks-index"}`
+		body := `{"name":"fraud-policies-index","version":"1","type":"AzureSearch","id":"idx_abc","connectionName":"search-conn","indexName":"fraud-policies-ks-index"}`
 		return newProbeResponse(http.StatusOK, body), nil
 	})
 
@@ -126,6 +126,67 @@ func TestDeleteProjectIndex_NoBodyOnSuccess(t *testing.T) {
 	}
 }
 
+// TestCreateOrUpdateProjectIndex_BodyIsFlatCamelCase pins the wire shape
+// against issue #14. Foundry's PATCH handler validates the flat envelope:
+// it expects connectionName / indexName / fieldMapping at the top level
+// alongside type, NOT nested under an azureSearch sub-object NOR using
+// snake_case keys. v0.8.2 / v0.8.3 used snake_case (connection_name /
+// index_name / field_mapping) and got HTTP 400 "ConnectionName field is
+// required" because Foundry didn't recognize the keys.
+//
+// The test asserts the raw bytes — not just a struct round-trip — so a
+// future tag drift back to snake_case fails loudly.
+func TestCreateOrUpdateProjectIndex_BodyIsFlatCamelCase(t *testing.T) {
+	t.Parallel()
+
+	rt := roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		buf := make([]byte, r.ContentLength)
+		if _, err := r.Body.Read(buf); err != nil && err.Error() != "EOF" {
+			t.Fatalf("reading body: %v", err)
+		}
+		raw := string(buf)
+
+		// Required keys live at the TOP level alongside type, in camelCase.
+		mustContain := []string{
+			`"type":"AzureSearch"`,
+			`"connectionName":"search-conn"`,
+			`"indexName":"fraud-policies-ks-index"`,
+		}
+		for _, want := range mustContain {
+			if !strings.Contains(raw, want) {
+				t.Errorf("expected body to contain %q, got %s", want, raw)
+			}
+		}
+
+		// Specific anti-patterns from the v0.8.2 / v0.8.3 regression: no
+		// snake_case keys, no azureSearch sub-envelope.
+		mustNotContain := []string{
+			`"connection_name"`,
+			`"index_name"`,
+			`"field_mapping"`,
+			`"azureSearch"`,
+			`"azure_search"`,
+		}
+		for _, no := range mustNotContain {
+			if strings.Contains(raw, no) {
+				t.Errorf("body must not contain %q, got %s", no, raw)
+			}
+		}
+
+		return newProbeResponse(http.StatusOK, `{"name":"x","version":"1","type":"AzureSearch","connectionName":"search-conn","indexName":"fraud-policies-ks-index"}`), nil
+	})
+
+	c := newTestClient(rt)
+	if _, err := c.CreateOrUpdateProjectIndex(context.Background(), ProjectIndex{
+		Name:           "x",
+		Type:           ProjectIndexTypeAzureSearch,
+		ConnectionName: "search-conn",
+		IndexName:      "fraud-policies-ks-index",
+	}); err != nil {
+		t.Fatalf("CreateOrUpdateProjectIndex: %v", err)
+	}
+}
+
 func TestProjectIndex_FieldMappingRoundTrips(t *testing.T) {
 	t.Parallel()
 
@@ -144,7 +205,7 @@ func TestProjectIndex_FieldMappingRoundTrips(t *testing.T) {
 			t.Errorf("unexpected url_field: %q", payload.FieldMapping.URLField)
 		}
 
-		body := `{"name":"x","version":"1","type":"AzureSearch","connection_name":"c","index_name":"i","field_mapping":{"content_fields":["title","body"],"url_field":"source_url"}}`
+		body := `{"name":"x","version":"1","type":"AzureSearch","connectionName":"c","indexName":"i","fieldMapping":{"contentFields":["title","body"],"urlField":"source_url"}}`
 		return newProbeResponse(http.StatusOK, body), nil
 	})
 


### PR DESCRIPTION
Closes #14.

## Root cause

v0.8.3 fixed the HTTP verb (PUT → PATCH from #12), but the request body still didn't validate against Foundry's handler. The struct was already flat (no `azureSearch:` envelope, contrary to the issue's hypothesis), but the JSON tags used **snake_case** while Foundry expects **camelCase**.

Verified verbatim against the SDK source — this is the canonical wire shape:

```python
# azure-ai-projects/azure/ai/projects/models/_models.py:1454-1460
class AzureAISearchIndex(Index, discriminator=\"AzureSearch\"):
    connection_name: str = rest_field(name=\"connectionName\", visibility=[\"create\"])
    index_name:      str = rest_field(name=\"indexName\", visibility=[\"create\"])
    field_mapping:   ... = rest_field(name=\"fieldMapping\", visibility=[\"create\"])

# .../models/_models.py:5071-5081 — FieldMapping
contentFields, filepathField, titleField, urlField, vectorFields, metadataFields
```

The reporter's authoritative diagnostic is the verbatim 200-response from a manual PATCH probe against `swedencentral`, which matches the SDK shape exactly.

## What changed

- **`ProjectIndex` JSON tags**: `connection_name` → `connectionName`, `index_name` → `indexName`, `field_mapping` → `fieldMapping`.
- **`FieldMapping` JSON tags**: `content_fields` → `contentFields`, `filepath_field` → `filepathField`, `title_field` → `titleField`, `url_field` → `urlField`, `vector_fields` → `vectorFields`, `metadata_fields` → `metadataFields`.
- **Nothing else.** Struct field names, the Plugin Framework schema (`azure_search { connection_name = … }` HCL stays the same), the resource CRUD, the HTTP method (PATCH from v0.8.3), api-version (`v1`), URL template, and content-type (`application/merge-patch+json`) are all unchanged.

## Regression test

The new `TestCreateOrUpdateProjectIndex_BodyIsFlatCamelCase` asserts the **raw outbound bytes**, not just a struct round-trip — explicitly rejecting both the snake_case (v0.8.2 / v0.8.3) and the hypothetical nested-`azureSearch` shapes the original issue speculated about. Future tag drift in either direction fails loudly.

## Lint config

Tagliatelle exclusion extended to `project_index_v2.go` for the same reason it covers the Search KS/KB files: the API uses camelCase while the project's lint convention is snake_case. No `//nolint:` directives — config-level exclusion only, per AGENTS.md.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race -short ./...` — 27 passed across 4 packages (1 new regression test pinning camelCase wire shape)
- [x] `golangci-lint run ./...` — no issues
- [ ] **Live verification by the reporter** — the actual repro lives on `swedencentral`. Unit tests now pin the wire shape but don't catch a subsequent live regression. The 200-response shape captured on issue #14 is what we're now sending; if it still 400s, there's a *fourth* trap (unlikely given we now match the SDK's `rest_field` annotations exactly).

## Side-effect note

The reporter's diagnostic PATCH that produced a 200 *did* create a real registration in their consumer project (`fraud-policies-index` v1). After this provider fix lands they can either `terraform import` it or DELETE it out-of-band before re-applying.

## Releases as

`v0.8.4`. Patch bump.