### PR TITLE
fix(toolbox): add knowledge_base attribute to tools schema

### DIFF
--- a/docs/resources/toolbox_v2.md
+++ b/docs/resources/toolbox_v2.md
@@ -179,6 +179,7 @@ Optional:
 - `bing_grounding` (Attributes) Bing Search v7 grounding via a project connection. Used when `type = "bing_grounding"`. (see [below for nested schema](#nestedatt--tools--bing_grounding))
 - `code_interpreter` (Attributes) Sandboxed Python execution. Used when `type = "code_interpreter"`. (see [below for nested schema](#nestedatt--tools--code_interpreter))
 - `function` (Attributes) OpenAI-style function calling. Used when `type = "function"`. (see [below for nested schema](#nestedatt--tools--function))
+- `knowledge_base` (Attributes) Foundry IQ knowledge base shorthand. Used when `type = "knowledge_base"`. The provider expands this at extract time into a wire-level `mcp` tool block with `allowed_tools = ["knowledge_base_retrieve"]` and `server_url = knowledge_base_endpoint`. Mirrors the same block on `azurefoundry_agent_v2.tools[*]`; the toolbox surfaces it for completeness — most KB attaches happen on the agent side. (see [below for nested schema](#nestedatt--tools--knowledge_base))
 - `max_num_results` (Number) Maximum search hits returned per query. Used when `type = "file_search"`.
 - `mcp` (Attributes) Model Context Protocol server. Used when `type = "mcp"`. Most common toolbox variant — pair with a `RemoteTool`-category project connection for authenticated upstreams. (see [below for nested schema](#nestedatt--tools--mcp))
 - `memory_search` (Attributes) Attach a Foundry Memory store (preview). Used when `type = "memory_search"`. (see [below for nested schema](#nestedatt--tools--memory_search))
@@ -234,6 +235,21 @@ Optional:
 
 - `description` (String) Human-readable description shown to the model.
 - `parameters_json` (String) JSON Schema (as a string) for the function's parameters.
+
+
+<a id="nestedatt--tools--knowledge_base"></a>
+### Nested Schema for `tools.knowledge_base`
+
+Required:
+
+- `knowledge_base_endpoint` (String) MCP endpoint of the knowledge base. Wire `azurefoundry_knowledge_base.X.mcp_endpoint` directly into this attribute.
+- `project_connection_id` (String) Project connection (RemoteTool, ProjectManagedIdentity, audience=`https://search.azure.com/`) authorizing the toolbox to call the KB. Manage it via `azurerm_cognitive_account_project_connection` or `azure-native:cognitiveservices:Connection` — pass its name here.
+
+Optional:
+
+- `headers` (Map of String, Sensitive) Optional HTTP headers, e.g. `x-ms-query-source-authorization` for remote-SharePoint per-user ACL enforcement. Marked sensitive — values are redacted from plan / state output.
+- `require_approval` (String) `always`, `never`, or omitted (Foundry default). Defaults to `"never"` for the typed variant — KB lookups are read-only.
+- `server_label` (String) Display label shown in tool-call traces. Defaults to `"knowledge-base"`.
 
 
 <a id="nestedatt--tools--mcp"></a>

--- a/internal/resources/foundry_toolbox_v2.go
+++ b/internal/resources/foundry_toolbox_v2.go
@@ -288,6 +288,45 @@ func toolboxToolsNestedBlock() schema.NestedBlockObject {
 					"update_delay":      schema.Int64Attribute{MarkdownDescription: "Seconds of inactivity before extracted memories are written back.", Optional: true},
 				},
 			},
+			// Mirrors the agent_v2 schema. Required even if the typed
+			// shorthand is rarely used inside a toolbox: extractV2Tools
+			// deserializes the toolbox tool list into the SAME toolModelV2
+			// struct the agent uses, and that struct has a knowledge_base
+			// field. Without this attribute the framework's struct↔object
+			// converter raises "Struct defines fields not found in object:
+			// knowledge_base" before any of our resource code runs (#PR-17).
+			"knowledge_base": schema.SingleNestedAttribute{
+				MarkdownDescription: "Foundry IQ knowledge base shorthand. Used when `type = \"knowledge_base\"`. " +
+					"The provider expands this at extract time into a wire-level `mcp` tool block with " +
+					"`allowed_tools = [\"knowledge_base_retrieve\"]` and `server_url = knowledge_base_endpoint`. " +
+					"Mirrors the same block on `azurefoundry_agent_v2.tools[*]`; the toolbox surfaces it for " +
+					"completeness — most KB attaches happen on the agent side.",
+				Optional: true,
+				Attributes: map[string]schema.Attribute{
+					"knowledge_base_endpoint": schema.StringAttribute{
+						MarkdownDescription: "MCP endpoint of the knowledge base. Wire `azurefoundry_knowledge_base.X.mcp_endpoint` directly into this attribute.",
+						Required:            true,
+					},
+					"project_connection_id": schema.StringAttribute{
+						MarkdownDescription: "Project connection (RemoteTool, ProjectManagedIdentity, audience=`https://search.azure.com/`) authorizing the toolbox to call the KB. Manage it via `azurerm_cognitive_account_project_connection` or `azure-native:cognitiveservices:Connection` — pass its name here.",
+						Required:            true,
+					},
+					"server_label": schema.StringAttribute{
+						MarkdownDescription: "Display label shown in tool-call traces. Defaults to `\"knowledge-base\"`.",
+						Optional:            true,
+					},
+					"require_approval": schema.StringAttribute{
+						MarkdownDescription: "`always`, `never`, or omitted (Foundry default). Defaults to `\"never\"` for the typed variant — KB lookups are read-only.",
+						Optional:            true,
+					},
+					"headers": schema.MapAttribute{
+						MarkdownDescription: "Optional HTTP headers, e.g. `x-ms-query-source-authorization` for remote-SharePoint per-user ACL enforcement. Marked sensitive — values are redacted from plan / state output.",
+						Optional:            true,
+						Sensitive:           true,
+						ElementType:         types.StringType,
+					},
+				},
+			},
 		},
 	}
 }


### PR DESCRIPTION
**Urgent — fixes a regression introduced in v0.8.0 that breaks every `azurefoundry_toolbox_v2` apply.**

## Symptom

```
azurefoundry:index:ToolboxV2 (fraud-ops-toolbox):
  error: [ElementKeyInt(0)] Value Conversion Error: …
    mismatch between struct and object: Struct defines fields not
    found in object: knowledge_base.
```

## Root cause

v0.8.0 added the typed `knowledge_base` shorthand variant to `azurefoundry_agent_v2.tools[*]`. That added a `KnowledgeBase types.Object \`tfsdk:\"knowledge_base\"\`` field to the shared `toolModelV2` struct (`resources/foundry_agent_v2.go:110`).

The toolbox resource deserializes its `tools[*]` list into the **same struct** via `extractV2Tools` → `tools.ElementsAs(ctx, &tools, false)`, but the toolbox's nested block schema (`toolboxToolsNestedBlock`) was never updated to include the matching `knowledge_base` attribute. Plugin Framework's struct↔object converter does strict field-name comparison, so every toolbox apply has been failing since v0.8.0 — the schema mismatch trips before any resource code runs.

Verified by reading both files; the error message is the framework's literal output for this exact mismatch class.

## Fix

Add `knowledge_base` to the toolbox tools schema mirroring the agent_v2 block — same five attributes (`knowledge_base_endpoint`, `project_connection_id`, `server_label`, `require_approval`, `headers`), same types as `knowledgeBaseAttrTypes`. New attribute is `Optional`, so existing toolbox HCL that never references it plans clean.

If a user does set `knowledge_base` inside a toolbox, `extractKnowledgeBaseTool` (already shared via `toolExtractors`) expands it to a wire-level `mcp` tool with `allowed_tools=[\"knowledge_base_retrieve\"]`. `mcp` is an explicitly supported toolbox tool type per the [toolbox docs](https://learn.microsoft.com/azure/foundry/agents/how-to/tools/toolbox#configure-tools), so the path is valid.

## Why no new test

The bug is caught by the Plugin Framework's runtime conversion check — there's no wire-shape change to assert. Existing 27 unit tests still pass. A toolbox apply that previously errored on Create now plans and applies normally.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race -short ./...` — 27 passed across 4 packages
- [x] `golangci-lint run ./...` — no issues
- [ ] **Live verification**: the demo apply that triggered the report should now succeed.

## Releases as

`v0.8.5`. Patch bump.